### PR TITLE
feat: Add author profile component to blog posts

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 import { formatDate, getBlogPosts } from 'app/blog/utils'
 import { baseUrl } from 'app/sitemap'
 import { marked } from 'marked'
+import AuthorProfile from 'app/components/author-profile'
 
 export async function generateStaticParams() {
   let posts = getBlogPosts()
@@ -95,6 +96,15 @@ export default async function Blog({ params }) {
       <article className="prose">
         <div dangerouslySetInnerHTML={{ __html: marked(post.content) }} />
       </article>
+      {post.metadata.author && (
+        <AuthorProfile
+          author={post.metadata.author}
+          authorImage={post.metadata.authorImage}
+          authorBio={post.metadata.authorBio}
+          authorGithub={post.metadata.authorGithub}
+          authorTwitter={post.metadata.authorTwitter}
+        />
+      )}
     </section>
   )
 }

--- a/app/blog/posts/spaces-vs-tabs.mdx
+++ b/app/blog/posts/spaces-vs-tabs.mdx
@@ -2,6 +2,11 @@
 title: 'Spaces vs. Tabs: The Indentation Debate Continues'
 publishedAt: '2024-04-08'
 summary: 'Explore the enduring debate between using spaces and tabs for code indentation, and why this choice matters more than you might think.'
+author: 'Alex Developer'
+authorImage: '/avatar.svg'
+authorBio: 'Passionate full-stack developer with 10+ years of experience. Love clean code and good coffee.'
+authorGithub: 'https://github.com'
+authorTwitter: 'https://twitter.com'
 ---
 
 The debate between using spaces and tabs for indentation in coding may seem trivial to the uninitiated, but it is a topic that continues to inspire passionate discussions among developers. This seemingly minor choice can affect code readability, maintenance, and even team dynamics.

--- a/app/blog/posts/static-typing.mdx
+++ b/app/blog/posts/static-typing.mdx
@@ -2,6 +2,11 @@
 title: 'The Power of Static Typing in Programming'
 publishedAt: '2024-04-07'
 summary: 'In the ever-evolving landscape of software development, the debate between dynamic and static typing continues to be a hot topic.'
+author: 'Sarah Code'
+authorImage: '/avatar.svg'
+authorBio: 'TypeScript enthusiast and software architect. Building scalable web applications.'
+authorGithub: 'https://github.com'
+authorTwitter: 'https://twitter.com'
 ---
 
 In the ever-evolving landscape of software development, the debate between dynamic and static typing continues to be a hot topic. While dynamic typing offers flexibility and rapid development, static typing brings its own set of powerful advantages that can significantly improve the quality and maintainability of code. In this post, we'll explore why static typing is crucial for developers, accompanied by practical examples through markdown code snippets.

--- a/app/blog/posts/vim.mdx
+++ b/app/blog/posts/vim.mdx
@@ -2,6 +2,11 @@
 title: 'Embracing Vim: The Unsung Hero of Code Editors'
 publishedAt: '2024-04-09'
 summary: 'Discover why Vim, with its steep learning curve, remains a beloved tool among developers for editing code efficiently and effectively.'
+author: 'Michael Terminal'
+authorImage: '/avatar.svg'
+authorBio: 'Command-line ninja and Vim evangelist. Efficiency is my middle name.'
+authorGithub: 'https://github.com'
+authorTwitter: 'https://twitter.com'
 ---
 
 In the world of software development, where the latest and greatest tools frequently capture the spotlight, Vim stands out as a timeless classic. Despite its age and initial complexity, Vim has managed to retain a devoted following of developers who swear by its efficiency, versatility, and power.

--- a/app/blog/utils.ts
+++ b/app/blog/utils.ts
@@ -6,6 +6,11 @@ type Metadata = {
   publishedAt: string
   summary: string
   image?: string
+  author?: string
+  authorImage?: string
+  authorBio?: string
+  authorGithub?: string
+  authorTwitter?: string
 }
 
 function parseFrontmatter(fileContent: string) {

--- a/app/components/author-profile.tsx
+++ b/app/components/author-profile.tsx
@@ -1,0 +1,86 @@
+import Image from 'next/image'
+import Link from 'next/link'
+
+interface AuthorProfileProps {
+  author: string
+  authorImage?: string
+  authorBio?: string
+  authorGithub?: string
+  authorTwitter?: string
+}
+
+export default function AuthorProfile({
+  author,
+  authorImage,
+  authorBio,
+  authorGithub,
+  authorTwitter
+}: AuthorProfileProps) {
+  return (
+    <div className="mt-12 pt-8 border-t border-neutral-200 dark:border-neutral-700">
+      <div className="flex flex-col sm:flex-row items-center sm:items-start gap-4 bg-neutral-50 dark:bg-neutral-900 rounded-lg p-6">
+        {authorImage && (
+          <div className="flex-shrink-0">
+            <Image
+              src={authorImage}
+              alt={`${author}'s profile picture`}
+              width={80}
+              height={80}
+              className="rounded-full"
+            />
+          </div>
+        )}
+        <div className="flex-1 text-center sm:text-left">
+          <h3 className="text-lg font-semibold mb-2">{author}</h3>
+          {authorBio && (
+            <p className="text-sm text-neutral-600 dark:text-neutral-400 mb-3">
+              {authorBio}
+            </p>
+          )}
+          {(authorGithub || authorTwitter) && (
+            <div className="flex gap-3 justify-center sm:justify-start">
+              {authorGithub && (
+                <Link
+                  href={authorGithub}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors"
+                  aria-label="GitHub profile"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                  </svg>
+                </Link>
+              )}
+              {authorTwitter && (
+                <Link
+                  href={authorTwitter}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-neutral-600 dark:text-neutral-400 hover:text-neutral-900 dark:hover:text-neutral-100 transition-colors"
+                  aria-label="Twitter profile"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                  >
+                    <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+                  </svg>
+                </Link>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/public/avatar.svg
+++ b/public/avatar.svg
@@ -1,0 +1,5 @@
+<svg width="200" height="200" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <rect width="200" height="200" fill="#e5e7eb"/>
+  <circle cx="100" cy="70" r="30" fill="#9ca3af"/>
+  <ellipse cx="100" cy="145" rx="50" ry="35" fill="#9ca3af"/>
+</svg>


### PR DESCRIPTION
- Extended Metadata type with author information fields (name, image, bio, social links)
- Created reusable AuthorProfile component with responsive design and dark mode support
- Integrated author profile section below post content
- Added author metadata to all existing blog posts
- Created default avatar SVG for profile images

The author profile enhances reader engagement by providing a personal connection
to the content creator. The component is fully responsive and supports optional
social media links for GitHub and Twitter.

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>